### PR TITLE
Allow usage of symfony/finder:~3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=5.5.0",
         "nikic/php-parser": "~2.0",
-        "symfony/finder": "~2.7"
+        "symfony/finder": "~2.7|~3.0"
     },
     "require-dev": {
         "hanneskod/readme-tester": "dev-master"


### PR DESCRIPTION
See #7. Looks like the library works directly with Symfony 3.0