### PR TITLE
Laravel 7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=7.1",
         "nikic/php-parser": "^4",
-        "symfony/finder": "^4"
+        "symfony/finder": "^4|^5"
     },
     "require-dev": {
         "hanneskod/readme-tester": "dev-master",


### PR DESCRIPTION
Laravel 7 depends on symfony/finder 5 so I've bumped the symfony/finder version