### PR TITLE
Improve PHPUnit assertions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,11 @@
             "hanneskod\\classtools\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "hanneskod\\classtools\\": "tests/"
+        }
+    },
     "require": {
         "php": ">=7.2",
         "nikic/php-parser": "^4",

--- a/tests/Iterator/ClassIteratorTest.php
+++ b/tests/Iterator/ClassIteratorTest.php
@@ -273,7 +273,7 @@ namespace {
 
 EOL;
 
-        $this->assertEquals(
+        $this->assertSame(
             $expected,
             $this->getSystemUnderTest()->minimize()
         );

--- a/tests/Loader/ClassLoaderTest.php
+++ b/tests/Loader/ClassLoaderTest.php
@@ -25,7 +25,7 @@ class ClassLoaderTest extends \PHPUnit\Framework\TestCase
         $loader = new ClassLoader($iterator, true);
 
         $unloadedClass = new \UnloadedClass;
-        $this->assertEquals('bar', $unloadedClass->foo());
+        $this->assertSame('bar', $unloadedClass->foo());
 
         $loader->unregister();
     }

--- a/tests/NameTest.php
+++ b/tests/NameTest.php
@@ -81,7 +81,7 @@ class NameTest extends \PHPUnit\Framework\TestCase
 
     public function testNormalize()
     {
-        $this->assertEquals(
+        $this->assertSame(
             '',
             (new Name('\\'))->normalize()
         );

--- a/tests/Transformer/Action/CommentStripperTest.php
+++ b/tests/Transformer/Action/CommentStripperTest.php
@@ -61,7 +61,7 @@ EOF;
 
         $writer = new Writer;
         $writer->apply(new CommentStripper);
-        $this->assertEquals(
+        $this->assertSame(
             $expected,
             $writer->write($reader->read('ClassName'))
         );

--- a/tests/Transformer/Action/NamespaceCrawlerTest.php
+++ b/tests/Transformer/Action/NamespaceCrawlerTest.php
@@ -44,7 +44,7 @@ EOF;
         $writer = new Writer;
         $writer->apply(new NameResolver);
         $writer->apply(new NamespaceCrawler(['\hanneskod\classtools\Transformer\Action']));
-        $this->assertEquals(
+        $this->assertSame(
             $expected,
             $writer->write($reader->read('ClassName'))
         );
@@ -94,6 +94,6 @@ EOF
         $writer->apply(new NamespaceCrawler([''], ['whitelist']));
 
         // NonExistingClass does not resolve, but no exception is thrown
-        $this->assertTrue(is_string($writer->write($reader->read('ClassName'))));
+        $this->assertIsString($writer->write($reader->read('ClassName')));
     }
 }

--- a/tests/Transformer/Action/NamespaceWrapperTest.php
+++ b/tests/Transformer/Action/NamespaceWrapperTest.php
@@ -42,11 +42,11 @@ EOF;
 
         $writer = new Writer;
         $writer->apply(new NamespaceWrapper('NamespaceName'));
-        $this->assertEquals(
+        $this->assertSame(
             $expected,
             $writer->write($readerOne->read('ClassName'))
         );
-        $this->assertEquals(
+        $this->assertSame(
             $expected,
             $writer->write($readerTwo->read('ClassName'))
         );
@@ -76,7 +76,7 @@ EOF;
 
         $writer = new Writer;
         $writer->apply(new NamespaceWrapper('extended'));
-        $this->assertEquals(
+        $this->assertSame(
             $expected,
             $writer->write($reader->read('NamespaceName\ClassName'))
         );
@@ -107,7 +107,7 @@ EOF;
         $writer = new Writer;
         // Assert that a empty second wrapper makes no difference
         $writer->apply(new NamespaceWrapper(''));
-        $this->assertEquals(
+        $this->assertSame(
             $expected,
             $writer->write($reader->read('foobar\ClassName'))
         );

--- a/tests/Transformer/Action/NodeStripperTest.php
+++ b/tests/Transformer/Action/NodeStripperTest.php
@@ -42,7 +42,7 @@ EOF;
 
         $writer = new Writer;
         $writer->apply(new NodeStripper('Stmt_Expression'));
-        $this->assertEquals(
+        $this->assertSame(
             $expected,
             $writer->write($reader->read('ClassName'))
         );

--- a/tests/Transformer/BracketingPrinterTest.php
+++ b/tests/Transformer/BracketingPrinterTest.php
@@ -32,6 +32,6 @@ namespace foo {
 }
 EOF;
 
-        $this->assertEquals($expected, $printer->prettyPrint($stmts));
+        $this->assertSame($expected, $printer->prettyPrint($stmts));
     }
 }

--- a/tests/Transformer/ReaderTest.php
+++ b/tests/Transformer/ReaderTest.php
@@ -97,20 +97,16 @@ EOF
     public function testRead()
     {
         $reader = new Reader('<?php class FooBar {}');
-        $this->assertTrue(
-            is_array(
-                $reader->read('FooBar')
-            )
+        $this->assertIsArray(
+            $reader->read('FooBar')
         );
     }
 
     public function testReadAll()
     {
         $reader = new Reader('');
-        $this->assertTrue(
-            is_array(
-                $reader->readAll()
-            )
+        $this->assertIsArray(
+            $reader->readAll()
         );
     }
 

--- a/tests/Transformer/UseStmtTranslationTest.php
+++ b/tests/Transformer/UseStmtTranslationTest.php
@@ -32,7 +32,7 @@ EOF;
 
         $writer = new Writer;
 
-        $this->assertEquals(
+        $this->assertSame(
             $expected,
             $writer->write($reader->read('foo\ClassName'))
         );
@@ -62,7 +62,7 @@ EOF;
 
         $writer = new Writer;
 
-        $this->assertEquals(
+        $this->assertSame(
             $expected,
             $writer->write($reader->read('ClassName'))
         );

--- a/tests/Transformer/WriterTest.php
+++ b/tests/Transformer/WriterTest.php
@@ -20,7 +20,7 @@ class WriterTest extends \PHPUnit\Framework\TestCase
     public function testWrite()
     {
         $writer = new Writer();
-        $this->assertEquals('', $writer->write([]));
+        $this->assertSame('', $writer->write([]));
     }
 
     public function testPhpParserException()


### PR DESCRIPTION
# Changed log

- Adding the `autoload-dev` setting for classes with `hanneskod\\classtools\\` namespace on `tests` folder.
- Using the `assertSame` to make assert equals checking strict.
- Using the `assertIsString` to make assert expected type is `string`.
- Using the `assertIsArray` to make assert expected type is `array`.