### PR TITLE
Add PHP 8 / phpunit 9.5 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 language: php
 
 php:
+    - 8.0
     - 7.4
     - 7.3
     - 7.2

--- a/phive.xml
+++ b/phive.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="phpunit" version="7" installed="7.5.20" location="./tools/phpunit" copy="false"/>
+  <phar name="phpunit" version="9" installed="9.5.0" location="./tools/phpunit" copy="false"/>
   <phar name="hanneskod/readme-tester" version="1" installed="1.0.0-beta5" location="./tools/readme-tester" copy="false"/>
   <phar name="phpstan" version="^0.12.14" installed="0.12.14" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="./tests/bootstrap.php">
-    <testsuites>
-        <testsuite name="default">
-            <directory suffix=".php">./tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./tests/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="default">
+      <directory suffix=".php">./tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/tests/Iterator/ClassIteratorTest.php
+++ b/tests/Iterator/ClassIteratorTest.php
@@ -11,7 +11,7 @@ class ClassIteratorTest extends \PHPUnit\Framework\TestCase
 {
     private static $sut;
 
-    public static function setupBeforeClass()
+    public static function setupBeforeClass(): void
     {
         MockFinder::setIterator(
             new \ArrayIterator([


### PR DESCRIPTION
Allow PHP 8 builds to pass.

PHP 8 requires a newer PHPunit version, upgraded this to PHPUnit 9.5, but note there is a depreciation warning for prophesize which will need to be addressed at some point before moving to PHPUnit 10.

"Deprecate Prophecy integration #4141"
https://github.com/sebastianbergmann/phpunit/issues/4141